### PR TITLE
Remove en-US from links to mozilla.org, so that l10n negociation can …

### DIFF
--- a/locales/en-US/messages.properties
+++ b/locales/en-US/messages.properties
@@ -33,7 +33,7 @@ episode_num=EPISODE {num}
 overview=Overview
 info=Info
 thanks_for_signup=Thanks for signing up!
-privacy_notice=I’m okay with Mozilla handling my info as explained in <a href="https://www.mozilla.org/en-US/privacy/websites/" target="_blank">this Privacy Notice</a>.
+privacy_notice=I’m okay with Mozilla handling my info as explained in <a href="https://www.mozilla.org/privacy/websites/" target="_blank">this Privacy Notice</a>.
 why_this_info=Why do we ask for this <a class="explaination-trigger">information?</a><div class="explaination">We care about your privacy and helping you make informed choices. That’s why we link to our Privacy Notice  so you can easily read it. To receive emails we require only your email address — “First Name” and “Country” aren’t required to sign up, but if you tell us your country we can send you local news and events — it’s your choice!</div>
 home=Home
 open_web_fellows=Open Web Fellows

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -13,8 +13,8 @@ module.exports = React.createClass({
           <Icon href="https://www.mozilla.org/contact/" src="/assets/footer-icon-help.svg" title="">{this.context.intl.formatMessage({id: 'contact_us'})}</Icon>
           <Icon href="https://twitter.com/Mozilla" src="/assets/footer-icon-twitter.svg" title="">{this.context.intl.formatMessage({id: 'connect_twitter'})}</Icon>
           {this.props.children}
-          <Icon href="https://www.mozilla.org/en-US/about/legal.html" src="/assets/footer-icon-terms.svg" title="">{this.context.intl.formatMessage({id: 'legal'})}</Icon>
-          <Icon href="https://www.mozilla.org/en-US/privacy/" src="/assets/footer-icon-privacy.svg" title="">{this.context.intl.formatMessage({id: 'privacy_policy'})}</Icon>
+          <Icon href="https://www.mozilla.org/about/legal.html" src="/assets/footer-icon-terms.svg" title="">{this.context.intl.formatMessage({id: 'legal'})}</Icon>
+          <Icon href="https://www.mozilla.org/privacy/" src="/assets/footer-icon-privacy.svg" title="">{this.context.intl.formatMessage({id: 'privacy_policy'})}</Icon>
           <Icon href="https://donate.mozilla.org" src="/assets/heart.svg" title="Heart">{this.context.intl.formatMessage({id: 'donate'})}</Icon>
         </div>
         <div className="footer-content">

--- a/src/pages/open-web-fellows/info.js
+++ b/src/pages/open-web-fellows/info.js
@@ -98,7 +98,7 @@ module.exports = React.createClass({
           <ContentContainer className="grey slant flat-top responsibilities">
             <h2>Fellow Responsibilities</h2>
             <h4>A commitment to teamwork and working in the open.</h4>
-            <p>The fellowship team includes the host organizations, Mozilla, and the fellows. We expect you to join the working teams of your host organization and contribute to the mission, organizational culture and work products of your host organization. Successful fellows will enjoy both teaching and learning; mentorship is core to this fellowship. We expect you to follow the interaction styles and inclusion principles in the <a href="https://www.mozilla.org/en-US/about/governance/policies/participation/">Mozilla Community Participation Guidelines</a>.</p>
+            <p>The fellowship team includes the host organizations, Mozilla, and the fellows. We expect you to join the working teams of your host organization and contribute to the mission, organizational culture and work products of your host organization. Successful fellows will enjoy both teaching and learning; mentorship is core to this fellowship. We expect you to follow the interaction styles and inclusion principles in the <a href="https://www.mozilla.org/about/governance/policies/participation/">Mozilla Community Participation Guidelines</a>.</p>
             <h4>Documentation</h4>
             <p>The Fellowship is an opportunity for you to reach new audiences – both in the general public, and professionally within the Internet policy and advocacy space. Mozilla and host organizations expect fellows to document their year publicly via blogs, code sharing, and events.</p>
             <h4>Calls</h4>


### PR DESCRIPTION
…happen
Some of those links are localized, removing en-US lets people see the page in their language, if available. Generally speaking, we should always remove en-US from links to mozilla.org :) 