### PR TITLE
Expose strings for home page

### DIFF
--- a/less/pages/open-web-fellows/shared.less
+++ b/less/pages/open-web-fellows/shared.less
@@ -43,7 +43,6 @@
 
   .button {
     border: 1px solid #FFFFFF;
-    text-transform: uppercase;
     height: 50px;
     padding: 4px 22px 0;
     display: inline-flex;

--- a/locales/en-US/fellows.properties
+++ b/locales/en-US/fellows.properties
@@ -1,4 +1,0 @@
-apply_desc=Thank you to everyone who applied. We will be contacting candidates directly in mid-April and announcing 2016 fellows in June.
-apply_desc_more=Thank you to everyone who applied. We will be contacting candidates directly in mid-April and announcing 2016 fellows in June. If you’re interested in what current fellows are doing, please visit our fellows page.
-fellows2015=2015 Fellows
-fellows2016=2016 Fellows

--- a/locales/en-US/home.properties
+++ b/locales/en-US/home.properties
@@ -1,10 +1,8 @@
-home_header=We Are Building a Global Movement to Protect the Free and Open Web
 new_intro=Your online privacy depends on encryption. Learn more about how encryption works, why it’s essential to a strong Web, and why it’s worth protecting.
 learn_more=LEARN MORE
+
+home_header=We Are Building a Global Movement to Protect the Free and Open Web
 home_intro=We believe the Internet is at its best as a global public resource, open and accessible to all. We also believe a healthy Internet requires an active, global community. mozilla Advocacy brings together individuals from around the world to educate on and fight for privacy, inclusion and literacy online.
-overview=Overview
-info=Info
-faq=FAQ
 
 activism_alt=net neutrality image
 activism_label=Tools for Activism

--- a/locales/en-US/home.properties
+++ b/locales/en-US/home.properties
@@ -1,5 +1,27 @@
 home_header=We Are Building a Global Movement to Protect the Free and Open Web
+new_intro=Your online privacy depends on encryption. Learn more about how encryption works, why it’s essential to a strong Web, and why it’s worth protecting.
+learn_more=LEARN MORE
 home_intro=We believe the Internet is at its best as a global public resource, open and accessible to all. We also believe a healthy Internet requires an active, global community. mozilla Advocacy brings together individuals from around the world to educate on and fight for privacy, inclusion and literacy online.
 overview=Overview
 info=Info
 faq=FAQ
+
+activism_alt=net neutrality image
+activism_label=Tools for Activism
+activism_description=From climate change to human rights, 21st century campaigns will be won and lost online. Check out this list of tools from Mozilla and our friends that help us organize, coordinate, communicate, mobilize and take collective action.
+activism_button=SEE THE LIST
+
+fellows_alt=open web fellows image
+fellows_label=Open Web Fellows
+fellows_description=The Open Web Fellows program places the best emerging technology talent at civil society organizations around the globe. As threats to digital freedom proliferate, it’s critical to have capable leaders.
+fellows_button=READ OUR YEAR 1 REPORT
+
+freedom_alt=usa freedom act image
+freedom_label=USA FREEDOM Act
+freedom_description=Mass Surveillance is a threat to privacy and trust online. Our community fought for the successful passage of the USA FREEDOM Act, a first step toward reforming mass surveillance.
+freedom_button=READ POST
+
+policy_alt=net policy blog image
+policy_label=Net Policy Blog
+policy_description=Mozilla’s team of policy experts and engineers are fighting for a free and open Internet. Read the latest developments and news on Our Net Policy blog.
+policy_button=READ POST

--- a/locales/en-US/home.properties
+++ b/locales/en-US/home.properties
@@ -1,24 +1,33 @@
+# Accessibility string for the Advocacy logo, not displayed in the page
+advocacy_alt=advocacy logo
+
+# Accessibility string for the Encrypt banner, not displayed in the page
+encrypt_alt=encrypt banner image
 new_intro=Your online privacy depends on encryption. Learn more about how encryption works, why it’s essential to a strong Web, and why it’s worth protecting.
 learn_more=LEARN MORE
 
 home_header=We Are Building a Global Movement to Protect the Free and Open Web
 home_intro=We believe the Internet is at its best as a global public resource, open and accessible to all. We also believe a healthy Internet requires an active, global community. mozilla Advocacy brings together individuals from around the world to educate on and fight for privacy, inclusion and literacy online.
 
+# Accessibility string, not displayed in the page
 activism_alt=net neutrality image
 activism_label=Tools for Activism
 activism_description=From climate change to human rights, 21st century campaigns will be won and lost online. Check out this list of tools from Mozilla and our friends that help us organize, coordinate, communicate, mobilize and take collective action.
 activism_button=SEE THE LIST
 
+# Accessibility string, not displayed in the page
 fellows_alt=open web fellows image
 fellows_label=Open Web Fellows
 fellows_description=The Open Web Fellows program places the best emerging technology talent at civil society organizations around the globe. As threats to digital freedom proliferate, it’s critical to have capable leaders.
 fellows_button=READ OUR YEAR 1 REPORT
 
+# Accessibility string, not displayed in the page
 freedom_alt=usa freedom act image
 freedom_label=USA FREEDOM Act
 freedom_description=Mass Surveillance is a threat to privacy and trust online. Our community fought for the successful passage of the USA FREEDOM Act, a first step toward reforming mass surveillance.
 freedom_button=READ POST
 
+# Accessibility string, not displayed in the page
 policy_alt=net policy blog image
 policy_label=Net Policy Blog
 policy_description=Mozilla’s team of policy experts and engineers are fighting for a free and open Internet. Read the latest developments and news on Our Net Policy blog.

--- a/src/components/fellows-header.js
+++ b/src/components/fellows-header.js
@@ -14,16 +14,16 @@ module.exports = React.createClass({
         <div className="fellow-header-overlay"></div>
         <div className="nav-items">
           <div className="nav-link-container current-fellows-link">
-            <Link to={"/" + locale + "/open-web-fellows/fellows2016"}>{this.context.intl.formatMessage({id: 'fellows2016'})}</Link>
+            <Link to={"/" + locale + "/open-web-fellows/fellows2016"}>2016 Fellows</Link>
           </div>
           <div className="nav-link-container past-fellows-link">
-            <Link to={"/" + locale + "/open-web-fellows/fellows2015"}>{this.context.intl.formatMessage({id: 'fellows2015'})}</Link>
+            <Link to={"/" + locale + "/open-web-fellows/fellows2015"}>2015 Fellows</Link>
           </div>
           <div className="nav-link-container overview-link">
-            <Link to={"/" + locale + "/open-web-fellows/overview"}>{this.context.intl.formatMessage({id: 'overview'})}</Link>
+            <Link to={"/" + locale + "/open-web-fellows/overview"}>Overview</Link>
           </div>
           <div className="nav-link-container info-link">
-            <Link to={"/" + locale + "/open-web-fellows/info"}>{this.context.intl.formatMessage({id: 'faq'})}</Link>
+            <Link to={"/" + locale + "/open-web-fellows/info"}>FAQ</Link>
           </div>
         </div>
       </StickyContainer>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -18,11 +18,11 @@ module.exports = React.createClass({
             <Link to={"/" + locale + "/"}>
               <div className="logo-fade">
                 <ImageTag src1x="/assets/logo-mozilla.svg"
-                  alt="advocacy logo"/>
+                  alt={this.context.intl.formatMessage({id: 'advocacy_alt'})}/>
               </div>
               <div>
                 <ImageTag src1x={logoImage}
-                  alt="advocacy logo"/>
+                  alt={this.context.intl.formatMessage({id: 'advocacy_alt'})}/>
               </div>
             </Link>
           </div>

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -35,9 +35,9 @@ module.exports = React.createClass({
         <Header/>
         <HeroUnit className="home-page-hero-unit">
           <ImageTag alt="encrypt banner image" width={790} src1x="/assets/encrypt/encrypt.svg"/>
-          <p className="intro">Your online privacy depends on encryption. Learn more about how encryption works, why it's essential to a strong Web, and why it's worth protecting.</p>
+          <p className="intro">{this.context.intl.formatMessage({id: 'new_intro'})}</p>
           <div>
-            <a href={"/" + locale + "/encrypt/"} className="button">learn more</a>
+            <a href={"/" + locale + "/encrypt/"} className="button">{this.context.intl.formatMessage({id: 'learn_more'})}</a>
           </div>
         </HeroUnit>
         <div className="page">
@@ -47,44 +47,44 @@ module.exports = React.createClass({
           </ContentContainer>
           <ContentContainer className="home-page-content grey center-align slant reverse flat-bottom">
             <HomePageItem
-              alt="net neutrality image"
+              alt={this.context.intl.formatMessage({id: 'activism_alt'})}
               src1x="/assets/digital-tools-for-activism.jpg"
               src2x="/assets/digital-tools-for-activism@2x.jpg"
-              label="Tools for Activism"
+              label={this.context.intl.formatMessage({id: 'activism_label'})}
               buttonHref="https://github.com/mozilla/toolsforactivism"
-              buttonLabel="see the list"
+              buttonLabel={this.context.intl.formatMessage({id: 'activism_button'})}
             >
-              From climate change to human rights, 21st century campaigns will be won and lost online. Check out this list of tools from Mozilla and our friends that help us organize, coordinate, communicate, mobilize and take collective action.
+              {this.context.intl.formatMessage({id: 'activism_description'})}
             </HomePageItem>
             <HomePageItem
-              alt="open web fellows image"
+              alt={this.context.intl.formatMessage({id: 'fellows_alt'})}
               src1x="/assets/home-fellows.jpg"
               src2x="/assets/home-fellows@2x.jpg"
-              label="Open Web Fellows"
+              label={this.context.intl.formatMessage({id: 'fellows_label'})}
               buttonHref="http://mozilla.github.io/content/open-web-fellows-report/#introduction"
-              buttonLabel="Read our Year 1 Report"
+              buttonLabel={this.context.intl.formatMessage({id: 'fellows_button'})}
             >
-              The Open Web Fellows program places the best emerging technology talent at civil society organizations around the globe. As threats to digital freedom proliferate, it's critical to have capable leaders.
+              {this.context.intl.formatMessage({id: 'fellows_description'})}
             </HomePageItem>
             <HomePageItem
-              alt="usa freedom act image"
+              alt={this.context.intl.formatMessage({id: 'freedom_alt'})}
               src1x="/assets/home-freedom.jpg"
               src2x="/assets/home-freedom@2x.jpg"
-              label="USA FREEDOM Act"
+              label={this.context.intl.formatMessage({id: 'freedom_label'})}
               buttonHref="https://blog.mozilla.org/netpolicy/2015/06/02/mozilla-applauds-u-s-senates-passage-of-the-usa-freedom-act/"
-              buttonLabel="read post"
+              buttonLabel={this.context.intl.formatMessage({id: 'freedom_button'})}
             >
-              Mass Surveillance is a threat to privacy and trust online. Our community fought for the successful passage of the USA FREEDOM Act, a first step toward reforming mass surveillance.
+              {this.context.intl.formatMessage({id: 'freedom_description'})}
             </HomePageItem>
             <HomePageItem
-              alt="net policy blog image"
+              alt={this.context.intl.formatMessage({id: 'policy_alt'})}
               src1x="/assets/home-policy.jpg"
               src2x="/assets/home-policy@2x.jpg"
-              label="Net Policy Blog"
+              label={this.context.intl.formatMessage({id: 'policy_label'})}
               buttonHref="https://blog.mozilla.org/netpolicy/"
-              buttonLabel="read post"
+              buttonLabel={this.context.intl.formatMessage({id: 'policy_button'})}
             >
-              Mozilla's team of policy experts and engineers are fighting for a free and open Internet. Read the latest developments and news on Our Net Policy blog.
+              {this.context.intl.formatMessage({id: 'policy_description'})}
             </HomePageItem>
           </ContentContainer>
         </div>

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -34,7 +34,7 @@ module.exports = React.createClass({
       <div className="home-page">
         <Header/>
         <HeroUnit className="home-page-hero-unit">
-          <ImageTag alt="encrypt banner image" width={790} src1x="/assets/encrypt/encrypt.svg"/>
+          <ImageTag alt={this.context.intl.formatMessage({id: 'encrypt_alt'})} width={790} src1x="/assets/encrypt/encrypt.svg"/>
           <p className="intro">{this.context.intl.formatMessage({id: 'new_intro'})}</p>
           <div>
             <a href={"/" + locale + "/encrypt/"} className="button">{this.context.intl.formatMessage({id: 'learn_more'})}</a>


### PR DESCRIPTION
Let’s get a fully localized homepage!
Also removing the few strings we have for Open Web Fellows. Right now, we have mixed translated/untranslated strings on prod [1] and I don’t think we can afford to translate everything for those pages.

[1] https://advocacy.mozilla.org/fr/open-web-fellows/fellows2016

Also removing `text-transform: uppercase;` because it can cause issues with some locales (https://developer.mozilla.org/en-US/docs/Mozilla/Localization/Localization_content_best_practices#CSS_issues)