### PR TITLE
remove reference to OWF 2016 projects in FAQ

### DIFF
--- a/src/pages/open-web-fellows/fellows2017.js
+++ b/src/pages/open-web-fellows/fellows2017.js
@@ -75,8 +75,8 @@ module.exports = React.createClass({
               image="/assets/fellows2017/Sarahk@2x.jpg"
               company="Research ICT Africa"
               companyHref="http://www.researchictafrica.net/home.php"
-              handle="skay319"
-              handleHref="https://twitter.com/skay319"
+              handle="MsKiden"
+              handleHref="https://twitter.com/MsKiden"
             >
               Sarah is a technologist, academic and trainer, passionate about Open Source solutions, Internet Policy and ICT for Development. She is on the core engineering team at Research and Education Network for Uganda, coordinating capacity building initiatives for Universities and Research Institutions in Uganda. She volunteers with the Internet Society Uganda Chapter, ICANN’s At-Large Advisory Committee, is a Board Advisor for One Mobile Projector per Trainer and a Co-Founder of DigiWave Africa. Sarah holds an MSc in Information Systems. As an Open Web Fellow, Sarah will be based at Research ICT Africa, where she will work on the Internet measurements project, focusing on broadband performance, Internet peering and users behavior.
             </FellowBlock>

--- a/src/pages/open-web-fellows/info.js
+++ b/src/pages/open-web-fellows/info.js
@@ -40,7 +40,7 @@ module.exports = React.createClass({
                 <p>Host organizations are selected via an open call for applications. The call for 2017 host organizations is now open. <a href="https://mozilla.forms.fm/2017-ford-mozilla-open-web-fellowship">Apply here</a>. If you’re interested in being a host organization or learning more, please contact <a href="mailto:vanessa@mozillafoundation.org">Vanessa Rhinesmith</a>, Program Manager.</p>
               </Panel>
               <Panel header={`What kind of projects do the fellows work on?`}>
-                <p>Fellows focus on three primary project areas during their participation in the fellowship: projects in development with the host organization, personal projects (either pre existing or new initiatives), and community created projects (with the fellowship cohort and or Mozilla’s Policy & Advocacy network at-large). A list of proposed 2016 host organization projects can be found <a href="https://blog.mozilla.org/netpolicy/2016/02/01/2016-open-web-fellows-program-host-organizations/" target="_blank">here</a>.</p>
+                <p>Fellows focus on three primary project areas during their participation in the fellowship: projects in development with the host organization, personal projects (either pre existing or new initiatives), and community created projects (with the fellowship cohort and or Mozilla’s Policy & Advocacy network at-large). </p>
               </Panel>
               <Panel header={`How are fellows funded over the fellowship?`}>
                 <p>{`Funding and additional supplements for which fellows may be eligible are allocated to the individual directly on a monthly basis.`}</p>


### PR DESCRIPTION
Small change in language per a recent discussion with the fellowships team.
- [x] eliminated reference to 2016 projects from the FAQ as an update for 2017.
- [x] updated one candidate's twitter handle

Thank you!