### PR TITLE
Remove faq from Open Web Fellows page

### DIFF
--- a/src/components/fellows-header.js
+++ b/src/components/fellows-header.js
@@ -25,9 +25,6 @@ module.exports = React.createClass({
           <div className="nav-link-container overview-link">
             <Link to={"/" + locale + "/open-web-fellows/overview"}>Overview</Link>
           </div>
-          <div className="nav-link-container info-link">
-            <a href="https://docs.google.com/document/d/1WLfmXOtIO4rtynR1pi6ekO0-NMjRFkVtLea3T8_KJ3o/">FAQ</a>
-          </div>
         </div>
       </StickyContainer>
     );


### PR DESCRIPTION
Hi there @ScottDowne + @alanmoo , 

Per a request from legal I'm removing the link to [this document](https://docs.google.com/document/d/1WLfmXOtIO4rtynR1pi6ekO0-NMjRFkVtLea3T8_KJ3o/edit#heading=h.24cyuyivs9fx) and the associated header item ("FAQ") on this page: https://advocacy.mozilla.org/en-US/open-web-fellows/

I believe I only need to do this in the `components/fellows-header.js` file but if you see it replicated elsewhere please ping me to also edit in other locations.

Page now looks like this when run locally:
![screen shot 2017-09-22 at 11 44 24 am](https://user-images.githubusercontent.com/1559703/30752818-73f01d2e-9f8b-11e7-86e9-a5ae4e10a44d.png)


Thank you!