### PR TITLE
Removed apply now banner from owf site

### DIFF
--- a/src/pages/open-web-fellows/overview.js
+++ b/src/pages/open-web-fellows/overview.js
@@ -5,7 +5,8 @@ var HeroUnit = require(`../../components/hero-unit.js`);
 var FellowsHeader = require(`../../components/fellows-header.js`);
 var ImageTag = require(`../../components/imagetag.js`);
 var ContentContainer = require(`../../components/content-container.js`);
-var ApplyBanner = require(`../../components/open-web-fellows/apply.js`);
+// removed banner because applications are closed
+// var ApplyBanner = require(`../../components/open-web-fellows/apply.js`);
 
 var Organization = React.createClass({
   render: function() {


### PR DESCRIPTION
cc @community-impact @annmarie123 

Our fellow Maya flagged that the "apply now" button/banner was still live on the OWF site. 

I just removed it (one line of code, rock on @alanmoo!).

I included the screenshot below.
![screencapture-127-0-0-1-8080-en-us-open-web-fellows-overview-2018-06-01-11_14_10](https://user-images.githubusercontent.com/1559703/40833131-510df7d6-658d-11e8-9eb9-910e26de3153.png)

