### PR TITLE
Make the locale always use uppercase region

### DIFF
--- a/src/lib/location-parser.js
+++ b/src/lib/location-parser.js
@@ -7,7 +7,8 @@ var locales = defaultLocales;
 
 function getLocale(acceptLang) {
   var langHeader = Parser.parse(acceptLang);
-  var langArray = langHeader.map(l => l.code + (l.region ? "-" + l.region : ""));
+  //We must uppercase the region because Safari likes to make it lowercase and that sometimes breaks weird things
+  var langArray = langHeader.map(l => l.code + (l.region ? "-" + l.region.toUpperCase() : ""));
   return bestLang(langArray, Object.keys(locales), 'en-US');
 }
 


### PR DESCRIPTION
Safari likes to redirect users to a lowercase region, that's annoying and breaking comments on the buyer's guide.